### PR TITLE
Fix officer year level eligibility requirements

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -261,7 +261,7 @@ unfilled. Only one member can occupy any elected position at a time.
 
 ### Candidacy and Eligibility
 Candidates for Primary Officer roles in the Society must meet the following
-minimum requirements:
+requirements by the start of the term in which they would take office:
 
 Position        | Year level    | Prior involvement
 ----------------|---------------|------------------


### PR DESCRIPTION
**This change will be handled by the amendment procedure specified in the SSE constitution.** Approval is dependent on a 2/3 majority vote of the Society members, where 2/3 of the Society participates in the poll.

Under the previous constitution, members who would have the required year level at the start of the required term were allowed to run for officer positions. Omitting this was an oversight by the Constitution Task Force in 2013.

Without this change, only students who are 4th years during the spring semester would be eligible for President in the next year, and only 3rd years would be eligible for Vice-President. This unnecessarily restricts the highest leadership roles, preventing students who may not have taken extra classes or arrived at RIT without extra transfer or AP credits from being eligible for these positions until later in their careers.
